### PR TITLE
chore: align deps and ruff target with Home Assistant 2026.4

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,7 +20,7 @@ jobs:
       - name: "Set up Python"
         uses: actions/setup-python@v6.2.0
         with:
-          python-version: "3.12"
+          python-version: "3.14"
           cache: "pip"
 
       - name: "Install requirements"

--- a/.github/workflows/pull_request_comment.yml
+++ b/.github/workflows/pull_request_comment.yml
@@ -20,7 +20,7 @@ jobs:
       - name: 'Set up Python'
         uses: actions/setup-python@v6.2.0
         with:
-          python-version: '3.12'
+          python-version: '3.14'
           cache: 'pip'
 
       - name: 'Install requirements'

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,6 +1,6 @@
 # The contents of this file is based on https://github.com/home-assistant/core/blob/dev/pyproject.toml
 
-target-version = "py310"
+target-version = "py314"
 
 line-length = 88
 

--- a/custom_components/blaulichtsms/_test_fixtures.py
+++ b/custom_components/blaulichtsms/_test_fixtures.py
@@ -3,12 +3,12 @@
 Not picked up by unittest discovery (filename does not match ``test*.py``).
 """
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 
 
 def make_alarm(alarm_id="A1", minutes_ago=0, recipients=None, end_minutes_ahead=None):
     """Build a minimal alarm dict for tests."""
-    alarm_date = datetime.now(timezone.utc) - timedelta(minutes=minutes_ago)
+    alarm_date = datetime.now(UTC) - timedelta(minutes=minutes_ago)
     alarm = {
         "alarmId": alarm_id,
         "alarmDate": alarm_date.isoformat(),
@@ -16,7 +16,7 @@ def make_alarm(alarm_id="A1", minutes_ago=0, recipients=None, end_minutes_ahead=
     }
     if end_minutes_ahead is not None:
         alarm["endDate"] = (
-            datetime.now(timezone.utc) + timedelta(minutes=end_minutes_ahead)
+            datetime.now(UTC) + timedelta(minutes=end_minutes_ahead)
         ).isoformat()
     return alarm
 

--- a/custom_components/blaulichtsms/binary_sensor.py
+++ b/custom_components/blaulichtsms/binary_sensor.py
@@ -1,7 +1,7 @@
 """Blaulichtsms Binary Sensors."""
 
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.components.sensor import PLATFORM_SCHEMA
@@ -191,7 +191,7 @@ class BlaulichtSMSNewAlarmActiveSensor(_BlaulichtSMSBinarySensorBase):
         alarm_date = _parse_alarm_datetime(alarm.get("alarmDate"))
         if alarm_date is None:
             return False
-        within_window = datetime.now(timezone.utc) < alarm_date + timedelta(
+        within_window = datetime.now(UTC) < alarm_date + timedelta(
             seconds=self._new_alarm_duration
         )
         if not within_window:

--- a/custom_components/blaulichtsms/blaulichtsms.py
+++ b/custom_components/blaulichtsms/blaulichtsms.py
@@ -2,7 +2,7 @@
 
 import copy
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 from pprint import pformat
 
 import aiohttp
@@ -139,7 +139,7 @@ class BlaulichtSmsController:
         """Return True if any alarm is currently active."""
         self.logger.debug("Checking for active alarms...")
         alarms = await self.get_alarms()
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         for alarm in alarms:
             alarm_datetime = _parse_alarm_datetime(alarm.get("alarmDate"))
             if alarm_datetime is None:
@@ -174,5 +174,5 @@ def _parse_alarm_datetime(raw: str | None) -> datetime | None:
     except ValueError:
         return None
     if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=timezone.utc)
+        parsed = parsed.replace(tzinfo=UTC)
     return parsed

--- a/custom_components/blaulichtsms/coordinator.py
+++ b/custom_components/blaulichtsms/coordinator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 
 import aiohttp
 
@@ -68,7 +68,7 @@ class BlaulichtSMSCoordinator(DataUpdateCoordinator):
             raise ConfigEntryAuthFailed(
                 f"Authentication with blaulichtSMS failed: {err}"
             ) from err
-        except (aiohttp.ClientError, asyncio.TimeoutError) as err:
+        except (TimeoutError, aiohttp.ClientError) as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err
 
         return {
@@ -81,7 +81,7 @@ class BlaulichtSMSCoordinator(DataUpdateCoordinator):
         if not alarm:
             return False
 
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
 
         end_date_raw = alarm.get("endDate")
         if end_date_raw:

--- a/custom_components/blaulichtsms/test_coordinator.py
+++ b/custom_components/blaulichtsms/test_coordinator.py
@@ -1,7 +1,7 @@
 """Unit tests for BlaulichtSMSCoordinator."""
 
 import unittest
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 from unittest.mock import MagicMock
 
 from ._test_fixtures import make_alarm
@@ -45,7 +45,7 @@ class TestCoordinatorIsAlarmActive(unittest.TestCase):
         coordinator = self._make_coordinator(alarm_duration_seconds=3600)
         alarm = make_alarm(minutes_ago=5)
         alarm["endDate"] = (
-            datetime.now(timezone.utc) - timedelta(minutes=1)
+            datetime.now(UTC) - timedelta(minutes=1)
         ).isoformat()
         self.assertFalse(coordinator._is_alarm_active(alarm))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-aiodns>=3.2.0
-aiohttp>=3.9
+aiodns>=4.0.0
+aiohttp>=3.13.5
 homeassistant>=2024.5.1
 pytest>=8.0
 pytest-asyncio>=0.23


### PR DESCRIPTION
## Summary
- Raise `aiodns`/`aiohttp` floors in `requirements.txt` to match HA 2026.4.x pins (`aiodns==4.0.0`, `aiohttp==3.13.5`) so the local test env tracks what HA actually ships at runtime.
- Bump ruff `target-version` from `py310` to `py314` to reflect HA's current `requires-python>=3.14.2`.
- Apply resulting ruff autofixes: `asyncio.TimeoutError` → builtin `TimeoutError` and `timezone.utc` → `datetime.UTC`.

No runtime behavior change — `manifest.json` still declares no `requirements`, so HA continues to supply `aiodns`/`aiohttp` at install time.

## Test plan
- [x] `uv run python -m ruff check` clean
- [x] `SKIP_INTEGRATION_TEST=true uv run python -m unittest discover -v` → 63 tests pass