### PR TITLE
fix(ci): use PAT for release-please so PR checks run

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## Summary

Pass `RELEASE_PLEASE_TOKEN` to `release-please-action` so release PRs are opened under a user identity, not `github-actions[bot]`. GitHub's recursion guard currently suppresses `pull_request.yml` on PRs created by the default `GITHUB_TOKEN` — PR #125 has no Lint/Test run for exactly this reason.

## Prerequisite before merge

Create a fine-grained PAT and store it as the repo secret `RELEASE_PLEASE_TOKEN`:

- https://github.com/settings/personal-access-tokens/new
- Resource owner: `r00tat`, repo access: `hassio_blaulichtsms` only
- Permissions: **Contents: Read and write**, **Pull requests: Read and write**

Then:

```
gh secret set RELEASE_PLEASE_TOKEN --repo r00tat/hassio_blaulichtsms
```

## Follow-up

- PR #125 (0.4.1) can be closed+reopened once this is merged + secret set, so CI runs on it.

## Test plan

- [x] `RELEASE_PLEASE_TOKEN` secret created
- [x] After merge, next release-please PR has Lint/Test checks attached