### PR TITLE
feat: shorten device name to BLSMS

### DIFF
--- a/custom_components/blaulichtsms/base.py
+++ b/custom_components/blaulichtsms/base.py
@@ -25,7 +25,7 @@ class BlaulichtSMSBaseEntity(CoordinatorEntity):
         customer_id = coordinator.api.customer_id
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, customer_id)},
-            name=f"BlaulichtSMS {customer_id}",
+            name="BLSMS",
             manufacturer="BlaulichtSMS",
             model="API",
             sw_version=VERSION,


### PR DESCRIPTION
## Summary
- Shorten the Home Assistant device name from `BlaulichtSMS <customerId>` to `BLSMS` so entity display names (e.g. `BLSMS Alarm text`) fit better in the UI.

## Test plan
- [x] `SKIP_INTEGRATION_TEST=true uv run python -m unittest discover -s custom_components/blaulichtsms -t .` (63 passed)
- [x] `uv run python -m ruff check`
- [ ] Verify sensor names in Home Assistant after deploying